### PR TITLE
Allow starting server via npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,20 +155,14 @@ npm run build
 
 #### 8. Start the server
 
-##### For Linux/Mac:
-```bash
-# Make sure the script is executable
-chmod +x start.sh
+Run the application after it has been built:
 
-# Run the application
-./start.sh
+```bash
+npm start
 ```
 
-The startup scripts will automatically:
-- Load environment variables from .env file
-- Construct DATABASE_URL from PostgreSQL variables if needed
-- Generate a SESSION_SECRET if not provided
-- Detect whether to run in production or development mode
+This command loads environment variables from `.env` and starts the compiled
+server from the `dist` directory.
 
 #### 9. Access the application
 Open your browser and navigate to:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
     "build": "vite build --config ./vite.config.ts && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-    "start": "node dist/index.js",
+    "start": "node -r ./load-env.js dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"
   },


### PR DESCRIPTION
## Summary
- load `.env` automatically when running `npm start`
- update documentation to start the server using `npm start`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_688cd7f9e91c833099b34966994826a3