### PR TITLE
chore: disable runtime error overlay in production

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,9 @@ const __dirname = path.dirname(__filename);
 export default defineConfig({
   plugins: [
     react(),
-    runtimeErrorOverlay(),
+    ...(process.env.NODE_ENV !== "production"
+      ? [runtimeErrorOverlay()]
+      : []),
     themePlugin(),
     ...(process.env.NODE_ENV !== "production" &&
     process.env.REPL_ID !== undefined


### PR DESCRIPTION
## Summary
- only include the runtime error overlay plugin during development

## Testing
- `npm run build`
- `NODE_ENV=production npx tsx --eval "import('./vite.config.ts').then(m => console.log(m.default.plugins.map(p => p && p.name)))"`


------
https://chatgpt.com/codex/tasks/task_e_688db993a4788330ab309db3c96f1e93