### PR TITLE
fix start script to use dist/public

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -33,7 +33,7 @@ if [ -z "$SESSION_SECRET" ]; then
 fi
 
 # Determine mode
-if [ -d "dist/client" ] && [ -f "dist/index.js" ]; then
+if [ -d "dist/public" ] && [ -f "dist/index.js" ]; then
   echo "Starting in PRODUCTION mode..."
   NODE_ENV=production node dist/index.js
 else

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,22 +4,22 @@ import react from "@vitejs/plugin-react";
 import themePlugin from "@replit/vite-plugin-shadcn-theme-json";
 import path from "path";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-export default defineConfig({
-  plugins: [
+export default defineConfig(async () => {
+  const plugins = [
     react(),
-    ...(process.env.NODE_ENV !== "production"
-      ? [runtimeErrorOverlay()]
-      : []),
+    ...(process.env.NODE_ENV !== "production" ? [runtimeErrorOverlay()] : []),
     themePlugin(),
-    ...(process.env.NODE_ENV !== "production" &&
+  ];
+
+  if (
+    process.env.NODE_ENV !== "production" &&
     process.env.REPL_ID !== undefined
   ) {
-    const { cartographer } = await import(
-      "@replit/vite-plugin-cartographer"
-    );
+    const { cartographer } = await import("@replit/vite-plugin-cartographer");
     plugins.push(cartographer());
   }
 
@@ -39,3 +39,4 @@ export default defineConfig({
     },
   };
 });
+


### PR DESCRIPTION
## Summary
- fix start script to check for built client in `dist/public`
- restore Vite config with async setup and output to `dist/public`

## Testing
- `npm run build`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db ./start.sh` and `curl -I http://localhost:5000/assets/index-BgrXUPPg.css`


------
https://chatgpt.com/codex/tasks/task_e_688dca939b048330b0405039aee2d74e