### PR TITLE
build: output client assets to dist root

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ npm install --save-dev vite @vitejs/plugin-react esbuild typescript @replit/vite
 ```
 
 #### 7. Build the application
-Run the production build so the `dist/public` directory is generated:
+Run the production build so the `dist` directory is generated:
 ```bash
 npm run build
 ```

--- a/server/client-path.ts
+++ b/server/client-path.ts
@@ -24,5 +24,5 @@ export function getClientIndexPath(): string {
  * @returns {string} - Absolute path to the client's build directory
  */
 export function getClientBuildDir(): string {
-  return path.resolve(process.cwd(), 'public');
+  return path.resolve(process.cwd(), 'dist');
 }

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -73,12 +73,12 @@ export async function setupVite(app: Express, server: Server) {
 
 export function serveStatic(app: Express) {
   // When running the server in production we expect the client
-  // build output to live in the top-level `dist/public` directory.
+  // build output to live directly in the top-level `dist` directory.
   // In development the server is executed from the `server` directory
   // while the compiled production build runs from `dist`. Resolving the
   // path using the project root ensures static files are found in both
   // scenarios.
-  const distPath = path.resolve(__dirname, "..", "dist", "public");
+  const distPath = path.resolve(__dirname, "..", "dist");
 
   if (!fs.existsSync(distPath)) {
     throw new Error(

--- a/start.sh
+++ b/start.sh
@@ -33,7 +33,7 @@ if [ -z "$SESSION_SECRET" ]; then
 fi
 
 # Determine mode
-if [ -d "dist/public" ] && [ -f "dist/index.js" ]; then
+if [ -f "dist/index.html" ] && [ -f "dist/index.js" ]; then
   echo "Starting in PRODUCTION mode..."
   NODE_ENV=production node dist/index.js
 else

--- a/vite.config.alternative.ts
+++ b/vite.config.alternative.ts
@@ -32,7 +32,9 @@ export default defineConfig({
   },
   root: path.resolve(__dirname, "client"),
   build: {
-    outDir: path.resolve(__dirname, "dist/public"),
+    // Output client build directly to top-level dist folder
+    outDir: path.resolve(__dirname, "dist"),
+    assetsDir: "",
     emptyOutDir: true,
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,7 +34,9 @@ export default defineConfig(async () => {
     },
     root: path.resolve(__dirname, "client"),
     build: {
-      outDir: path.resolve(__dirname, "dist/public"),
+      // Output client build directly to top-level dist folder
+      outDir: path.resolve(__dirname, "dist"),
+      assetsDir: "",
       emptyOutDir: true,
     },
   };


### PR DESCRIPTION
## Summary
- direct Vite build output to `dist` instead of `dist/public`
- serve static assets from top-level `dist` folder in production
- update start script and docs for new build location

## Testing
- `npm run check`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688e1336281483308b904a0bab5d2387