### PR TITLE
Add user recovery fields to SQL setup scripts

### DIFF
--- a/scripts/create_tables.sql
+++ b/scripts/create_tables.sql
@@ -15,7 +15,10 @@ CREATE TABLE IF NOT EXISTS users (
   username TEXT NOT NULL UNIQUE,
   password TEXT NOT NULL,
   name TEXT NOT NULL,
+  email TEXT,
   account_id INTEGER NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  reset_token TEXT,
+  reset_token_expiry TIMESTAMP,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);

--- a/scripts/seed_data.sql
+++ b/scripts/seed_data.sql
@@ -10,8 +10,8 @@ RETURNING id;
 
 -- Insert admin user (password is 'admin123' - change in production!)
 -- Note: In production, use proper password hashing
-INSERT INTO users (username, password, name, account_id, created_at)
-VALUES ('admin', '$2b$10$Vt5xmUMkMZVR26myzEYVCeIdMEr8eVa.fBQmgn6S8Zrdi2XJ80Wca', 'Administrator', 1, NOW())
+INSERT INTO users (username, password, name, email, account_id, created_at)
+VALUES ('admin', '$2b$10$Vt5xmUMkMZVR26myzEYVCeIdMEr8eVa.fBQmgn6S8Zrdi2XJ80Wca', 'Administrator', 'admin@example.com', 1, NOW())
 ON CONFLICT (username) DO NOTHING;
 
 -- Insert sample contacts

--- a/scripts/setup.sql
+++ b/scripts/setup.sql
@@ -34,7 +34,10 @@ CREATE TABLE IF NOT EXISTS users (
   username TEXT NOT NULL UNIQUE,
   password TEXT NOT NULL,
   name TEXT NOT NULL,
+  email TEXT,
   account_id INTEGER NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  reset_token TEXT,
+  reset_token_expiry TIMESTAMP,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
@@ -107,8 +110,8 @@ VALUES ('Default Account', NOW())
 ON CONFLICT (id) DO NOTHING
 RETURNING id;
 
-INSERT INTO users (username, password, name, account_id, created_at)
-VALUES ('admin', '$2b$10$Vt5xmUMkMZVR26myzEYVCeIdMEr8eVa.fBQmgn6S8Zrdi2XJ80Wca', 'Administrator', 1, NOW())
+INSERT INTO users (username, password, name, email, account_id, created_at)
+VALUES ('admin', '$2b$10$Vt5xmUMkMZVR26myzEYVCeIdMEr8eVa.fBQmgn6S8Zrdi2XJ80Wca', 'Administrator', 'admin@example.com', 1, NOW())
 ON CONFLICT (username) DO NOTHING;
 
 INSERT INTO contacts (name, mobile, location, label, account_id, created_at)


### PR DESCRIPTION
## Summary
- include email and reset token columns in `users` table creation
- seed scripts now populate email for default admin user
- setup SQL updated to handle new user fields

## Testing
- `npm run check`
- `bash scripts/initialize_database.sh` *(fails: PostgreSQL client (psql) is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688e1d894df88330807c5d0eb127761a