### PR TITLE
Include env file in deployment release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,8 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          source: "dist/*"
+          # Include the generated .env file so each release has required env variables
+          source: "dist/*,.env"
           target: "/var/www/reach.cogzi.io/releases/${{ env.RELEASE_TIME }}"
           debug: true
 


### PR DESCRIPTION
## Summary
- ensure GitHub Actions deployment copies generated `.env` into each release

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68973fc6eeec8330b2710e37dd91d22e