### PR TITLE
Remove campaign and WABA API references

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,11 +339,9 @@ Campaign performance metrics
 Account-specific settings, including API configuration
 - `id`: Primary key
 - `account_id`: Foreign key to accounts table
-- `waba_api_url`: WhatsApp Business API URL
 - `facebook_access_token`: API token for Facebook
 - `partner_mobile`: Partner mobile number
 - `waba_id`: WhatsApp Business Account ID
-- `campaign_api_key`: API key for campaign launching
 - `updated_at`: Last update timestamp
 
 ### session

--- a/client/src/pages/settings-page.tsx
+++ b/client/src/pages/settings-page.tsx
@@ -29,22 +29,18 @@ import {
 export default function SettingsPage() {
   // State for WhatsApp Business API settings
   const [whatsappSettings, setWhatsappSettings] = useState({
-    wabaApiUrl: '',
     facebookAccessToken: '',
     partnerMobile: '',
-    wabaId: '',
-    campaignApiKey: ''
+    wabaId: ''
   });
   
   // Settings type definition
   interface SettingsData {
     id: number;
     accountId: number;
-    wabaApiUrl: string | null;
     facebookAccessToken: string | null;
     partnerMobile: string | null;
     wabaId: string | null;
-    campaignApiKey: string | null;
     updatedAt: string;
   }
 
@@ -61,11 +57,9 @@ export default function SettingsPage() {
   React.useEffect(() => {
     if (settings) {
       setWhatsappSettings({
-        wabaApiUrl: settings.wabaApiUrl ? settings.wabaApiUrl : '',
         facebookAccessToken: settings.facebookAccessToken ? settings.facebookAccessToken : '',
         partnerMobile: settings.partnerMobile ? settings.partnerMobile : '',
-        wabaId: settings.wabaId ? settings.wabaId : '',
-        campaignApiKey: settings.campaignApiKey ? settings.campaignApiKey : ''
+        wabaId: settings.wabaId ? settings.wabaId : ''
       });
     }
   }, [settings]);
@@ -473,24 +467,8 @@ export default function SettingsPage() {
                   <form onSubmit={handleSaveWhatsAppSettings}>
                     <div className="space-y-4 mb-4">
                       <div className="space-y-2">
-                        <Label htmlFor="wabaApiUrl">WhatsApp Business API URL</Label>
-                        <Input 
-                          id="wabaApiUrl"
-                          placeholder="Enter your WhatsApp Business API URL"
-                          value={whatsappSettings.wabaApiUrl}
-                          onChange={(e) => setWhatsappSettings({
-                            ...whatsappSettings,
-                            wabaApiUrl: e.target.value
-                          })}
-                        />
-                        <p className="text-xs text-gray-500">
-                          Full Graph API URL for fetching message templates (e.g., https://graph.facebook.com/v22.0/YOUR_WABA_ID/message_templates)
-                        </p>
-                      </div>
-                      
-                      <div className="space-y-2">
                         <Label htmlFor="facebookAccessToken">Facebook Access Token</Label>
-                        <Input 
+                        <Input
                           id="facebookAccessToken"
                           type="password"
                           placeholder="Enter your Facebook Access Token"
@@ -537,22 +515,6 @@ export default function SettingsPage() {
                         </p>
                       </div>
 
-                      <div className="space-y-2">
-                        <Label htmlFor="campaignApiKey">Campaign API Key</Label>
-                        <Input 
-                          id="campaignApiKey"
-                          type="password"
-                          placeholder="Enter your Campaign API Key"
-                          value={whatsappSettings.campaignApiKey}
-                          onChange={(e) => setWhatsappSettings({
-                            ...whatsappSettings,
-                            campaignApiKey: e.target.value
-                          })}
-                        />
-                        <p className="text-xs text-gray-500">
-                          API key for campaign service to authenticate API requests
-                        </p>
-                      </div>
                     </div>
                     
                     <div className="flex justify-end">

--- a/scripts/create_tables.sql
+++ b/scripts/create_tables.sql
@@ -85,7 +85,6 @@ CREATE INDEX IF NOT EXISTS idx_messages_contact_id ON messages(contact_id);
 CREATE TABLE IF NOT EXISTS settings (
   id SERIAL PRIMARY KEY,
   account_id INTEGER NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-  waba_api_url TEXT,
   facebook_access_token TEXT,
   partner_mobile TEXT,
   waba_id TEXT,

--- a/scripts/reset_all_tables.sql
+++ b/scripts/reset_all_tables.sql
@@ -77,11 +77,9 @@ CREATE TABLE "analytics" (
 CREATE TABLE "settings" (
   "id" serial PRIMARY KEY NOT NULL,
   "account_id" integer NOT NULL,
-  "waba_api_url" text,
   "facebook_access_token" text,
   "partner_mobile" text,
   "waba_id" text,
-  "campaign_api_key" text,
   "updated_at" timestamp DEFAULT now() NOT NULL,
   CONSTRAINT "settings_account_id_fkey" FOREIGN KEY ("account_id") REFERENCES "accounts"("id") ON DELETE CASCADE
 );

--- a/scripts/seed_data.sql
+++ b/scripts/seed_data.sql
@@ -37,9 +37,9 @@ VALUES
 ON CONFLICT DO NOTHING;
 
 -- Insert sample settings
-INSERT INTO settings (account_id, waba_api_url, facebook_access_token, partner_mobile, waba_id, updated_at)
-VALUES 
-  (1, 'https://graph.facebook.com/v17.0/123456789/message_templates', 'SAMPLE_FB_TOKEN', '+919876543210', 'waba_123456789', NOW())
+INSERT INTO settings (account_id, facebook_access_token, partner_mobile, waba_id, updated_at)
+VALUES
+  (1, 'SAMPLE_FB_TOKEN', '+919876543210', 'waba_123456789', NOW())
 ON CONFLICT DO NOTHING;
 
 -- Output success message

--- a/scripts/setup.sql
+++ b/scripts/setup.sql
@@ -87,7 +87,6 @@ CREATE INDEX IF NOT EXISTS idx_analytics_account_id ON analytics(account_id);
 CREATE TABLE IF NOT EXISTS settings (
   id SERIAL PRIMARY KEY,
   account_id INTEGER NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-  waba_api_url TEXT,
   facebook_access_token TEXT,
   partner_mobile TEXT,
   waba_id TEXT,
@@ -133,9 +132,9 @@ VALUES
   (2, 50, 48, 40, 2, 1, 1, 1, NOW())
 ON CONFLICT DO NOTHING;
 
-INSERT INTO settings (account_id, waba_api_url, facebook_access_token, partner_mobile, waba_id, updated_at)
+INSERT INTO settings (account_id, facebook_access_token, partner_mobile, waba_id, updated_at)
 VALUES
-  (1, 'https://graph.facebook.com/v17.0/123456789/message_templates', 'SAMPLE_FB_TOKEN', '+919876543210', 'waba_123456789', NOW())
+  (1, 'SAMPLE_FB_TOKEN', '+919876543210', 'waba_123456789', NOW())
 ON CONFLICT DO NOTHING;
 
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -81,20 +81,6 @@ export const SESSION_CONFIG = {
   debug: process.env.NODE_ENV !== 'production'
 };
 
-// API configurations
-export const API_CONFIG = {
-  // Campaign API settings
-  campaign: {
-    apiKey: process.env.CAMPAIGN_API_KEY,
-    apiUrl: process.env.CAMPAIGN_API_URL || "https://8x83b7rn4f.execute-api.ap-south-1.amazonaws.com/qa/campaign"
-  },
-  // WhatsApp Business API settings
-  waba: {
-    apiUrl: process.env.WABA_API_URL || "",
-    accessToken: process.env.WABA_ACCESS_TOKEN || ""
-  }
-};
-
 // Server configuration
 export const SERVER_CONFIG = {
   port: parseInt(process.env.PORT || '5000', 10),

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1013,15 +1013,13 @@ export class MemStorage implements IStorage {
     // Create new settings
     const id = this.settingsCurrentId++;
     const updatedAt = new Date();
-    const settings: Settings = { 
-      id, 
+    const settings: Settings = {
+      id,
       accountId,
       updatedAt,
-      wabaApiUrl: settingsData.wabaApiUrl || null,
       facebookAccessToken: settingsData.facebookAccessToken || null,
       partnerMobile: settingsData.partnerMobile || null,
-      wabaId: settingsData.wabaId || null,
-      campaignApiKey: settingsData.campaignApiKey || null
+      wabaId: settingsData.wabaId || null
     };
     this.settingsData.set(id, settings);
     return settings;

--- a/server/templates.ts
+++ b/server/templates.ts
@@ -13,15 +13,15 @@ export function createTemplatesRouter(checkAuth: (req: Request, res: Response, n
       // Get settings for the user's account
       const settings = await storage.getSettings(user.accountId);
 
-      if (!settings || !settings.wabaApiUrl || !settings.facebookAccessToken) {
+      if (!settings || !settings.wabaId || !settings.facebookAccessToken) {
         return res.status(400).json({
           message: "Facebook API settings not configured",
           code: "SETTINGS_MISSING",
         });
       }
 
-      // Facebook Graph API call using account-specific settings
-      const response = await fetch(`${settings.wabaApiUrl}`, {
+      // Facebook Graph API call using account-specific WABA ID
+      const response = await fetch(`https://graph.facebook.com/v17.0/${settings.wabaId}/message_templates`, {
         headers: {
           Authorization: `Bearer ${settings.facebookAccessToken}`,
         },

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -140,21 +140,17 @@ export type Message = typeof messages.$inferSelect;
 export const settings = pgTable("settings", {
   id: serial("id").primaryKey(),
   accountId: integer("account_id").notNull().references(() => accounts.id),
-  wabaApiUrl: text("waba_api_url"), // Full WhatsApp Business API URL
   facebookAccessToken: text("facebook_access_token"),
   partnerMobile: text("partner_mobile"), // Partner mobile number for campaign API
   wabaId: text("waba_id"), // WhatsApp Business Account ID
-  campaignApiKey: text("campaign_api_key"), // API key for campaign service
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
 
 export const insertSettingsSchema = createInsertSchema(settings).pick({
   accountId: true,
-  wabaApiUrl: true,
   facebookAccessToken: true,
   partnerMobile: true,
   wabaId: true,
-  campaignApiKey: true,
 });
 
 export type InsertSettings = z.infer<typeof insertSettingsSchema>;


### PR DESCRIPTION
## Summary
- drop campaign and WABA API fields from schema and setup scripts
- delete migration and environment config for deprecated API settings
- simplify campaign flows and update client settings UI

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689774cbc3548330974a10290c926e82