### PR TITLE
Fix campaign scheduling column mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Marketing campaigns created by users
 - `contact_label`: Optional label to filter contacts
 - `status`: Campaign status (draft, scheduled, sent, etc.)
 - `account_id`: Foreign key to accounts table
-- `scheduled_at`: Optional future scheduling timestamp
+- `scheduled_for`: Optional future scheduling timestamp
 - `created_at`: Creation timestamp
 
 ### analytics

--- a/scripts/create_tables.sql
+++ b/scripts/create_tables.sql
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS campaigns (
   contact_label TEXT,
   status TEXT NOT NULL DEFAULT 'draft',
   account_id INTEGER NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-  scheduled_at TIMESTAMP,
+  scheduled_for TIMESTAMP,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_campaigns_account_id ON campaigns(account_id);

--- a/scripts/seed_data.sql
+++ b/scripts/seed_data.sql
@@ -23,7 +23,7 @@ VALUES
 ON CONFLICT DO NOTHING;
 
 -- Insert sample campaign templates
-INSERT INTO campaigns (name, template, contact_label, status, account_id, scheduled_at, created_at)
+INSERT INTO campaigns (name, template, contact_label, status, account_id, scheduled_for, created_at)
 VALUES
   ('Welcome Campaign', 'welcome_template', 'Customer', 'draft', 1, NOW() + INTERVAL '1 day', NOW()),
   ('Special Offer', 'special_offer_template', 'VIP', 'draft', 1, NOW() + INTERVAL '2 days', NOW())

--- a/scripts/setup.sql
+++ b/scripts/setup.sql
@@ -63,7 +63,7 @@ CREATE TABLE IF NOT EXISTS campaigns (
   contact_label TEXT,
   status TEXT NOT NULL DEFAULT 'draft',
   account_id INTEGER NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-  scheduled_at TIMESTAMP,
+  scheduled_for TIMESTAMP,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_campaigns_account_id ON campaigns(account_id);
@@ -120,7 +120,7 @@ VALUES
   ('Bob Johnson', '5552223333', 'Chicago', 'Lead', 1, NOW())
 ON CONFLICT DO NOTHING;
 
-INSERT INTO campaigns (name, template, contact_label, status, account_id, scheduled_at, created_at)
+INSERT INTO campaigns (name, template, contact_label, status, account_id, scheduled_for, created_at)
 VALUES
   ('Welcome Campaign', 'welcome_template', 'Customer', 'draft', 1, NOW() + INTERVAL '1 day', NOW()),
   ('Special Offer', 'special_offer_template', 'VIP', 'draft', 1, NOW() + INTERVAL '2 days', NOW())


### PR DESCRIPTION
## Summary
- Align SQL scripts with `scheduled_for` column used by application
- Update documentation to reflect `scheduled_for` scheduling field

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68977b188fd8833084fab70f7eb82a1d